### PR TITLE
Empty match arms are ok for types that have no valid constructor.

### DIFF
--- a/sway-core/src/language/ty/expression/match_expression.rs
+++ b/sway-core/src/language/ty/expression/match_expression.rs
@@ -4,6 +4,7 @@ use crate::{language::ty::*, semantic_analysis::MatchReqMap, type_system::*};
 
 #[derive(Debug)]
 pub(crate) struct TyMatchExpression {
+    pub(crate) value_type_id: TypeId,
     pub(crate) branches: Vec<TyMatchBranch>,
     pub(crate) return_type_id: TypeId,
     pub(crate) span: Span,

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/usefulness.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/usefulness.rs
@@ -187,8 +187,8 @@ use super::{
 ///
 /// This algorithm checks is a match expression is exhaustive and if its match
 /// arms are reachable by applying the above definitions of usefulness and
-/// witnesses. This algorithm sequentionally creates a `WitnessReport` for every
-/// match arm by calling *U(P, q)*, where *P* is the `Matrix` of patterns seen
+/// witnesses. This algorithm sequentially creates a [WitnessReport] for every
+/// match arm by calling *U(P, q)*, where *P* is the [Matrix] of patterns seen
 /// so far and *q* is the current pattern under investigation for its
 /// reachability. A match arm is reachable if its `WitnessReport` is non-empty.
 /// Once all existing match arms have been analyzed, the match expression is
@@ -207,6 +207,17 @@ pub(crate) fn check_match_expression_usefulness(
     let mut errors = vec![];
     let mut matrix = Matrix::empty();
     let mut arms_reachability = vec![];
+
+    // If the provided type does has no valid constructor and there are no
+    // branches in the match expression (i.e. no scrutinees to check), then
+    // every scrutinee (i.e. 0 scrutinees) are useful! We return early in this
+    // case.
+    if !type_engine.look_up_type_id(type_id).has_valid_constructor() && scrutinees.is_empty() {
+        let witness_report = WitnessReport::NoWitnesses;
+        let arms_reachability = vec![];
+        return ok((witness_report, arms_reachability), warnings, errors);
+    }
+
     let factory = check!(
         ConstructorFactory::new(type_engine, type_id, &span),
         return err(warnings, errors),
@@ -257,7 +268,7 @@ pub(crate) fn check_match_expression_usefulness(
 /// everything else, and what we do for induction depends on what the first
 /// element of *q* is. Depending on if the first element of *q* is a wildcard
 /// pattern, or-pattern, or constructed pattern we do something different. Each
-/// case returns a witness report that we propogate through the recursive steps.
+/// case returns a witness report that we propagate through the recursive steps.
 fn is_useful(
     type_engine: &TypeEngine,
     factory: &ConstructorFactory,
@@ -557,7 +568,7 @@ fn is_useful_constructed(
     );
     if s_c_p_m > 0 && s_c_p_n != (c.a() + q.len() - 1) {
         errors.push(CompileError::Internal(
-            "S(c,P) matrix is misshappen",
+            "S(c,P) matrix is misshapen",
             span.clone(),
         ));
         return err(warnings, errors);
@@ -758,8 +769,8 @@ fn compute_specialized_matrix(c: &Pattern, p: &Matrix, span: &Span) -> CompileRe
 /// Given a constructor *c* and a `PatStack` *pⁱ* from `Matrix` *P*, compute the
 /// resulting row of the specialized `Matrix` *S(c, P)*.
 ///
-/// Intuition: a row in the specialized `Matrix` "expands itself" or "eliminates
-/// itself" depending on if its possible to furthur "drill down" into the
+/// Intuition: a row in the specialized [Matrix] "expands itself" or "eliminates
+/// itself" depending on if its possible to further "drill down" into the
 /// elements of *P* given a *c* that we are specializing for. It is possible to
 /// "drill down" when the first element of a row of *P* *pⁱ₁* matches *c* (in
 /// which case it is possible to "drill down" into the arguments for *pⁱ₁*),

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_expression.rs
@@ -43,6 +43,7 @@ impl ty::TyMatchExpression {
         }
 
         let typed_exp = ty::TyMatchExpression {
+            value_type_id: typed_value.return_type,
             branches: typed_branches,
             return_type_id: ctx.type_annotation(),
             span,
@@ -59,15 +60,13 @@ impl ty::TyMatchExpression {
 
         let type_engine = ctx.type_engine;
 
-        let ty::TyMatchExpression { branches, .. } = self;
-
         // create the typed if expression object that we will be building on to
         let mut typed_if_exp: Option<ty::TyExpression> = None;
 
         // for every branch of the match expression, in reverse
         for ty::TyMatchBranch {
             conditions, result, ..
-        } in branches.into_iter().rev()
+        } in self.branches.into_iter().rev()
         {
             // create the conditional that will act as the conditional for the if statement, in reverse
             let mut conditional: Option<ty::TyExpression> = None;
@@ -160,6 +159,50 @@ impl ty::TyMatchExpression {
         // return!
         match typed_if_exp {
             None => {
+                // If the type that we are matching on does not have a valid
+                // constructor, then it is expected that this algorithm finds a
+                // "None". This is because the user has not provided any
+                // branches in the match expression because the type cannot be
+                // constructed or matched upon. In this case, we manually create
+                // a typed expression that is equivalent to
+                // "if true { return; }" where the return type is manually set
+                // to be the return type of this typed match expression object.
+                //
+                // NOTE: This manual construction of the expression can (and
+                // most likely will) lead to an otherwise improperly typed
+                // expression, in most cases.
+                if !type_engine
+                    .look_up_type_id(self.value_type_id)
+                    .has_valid_constructor()
+                {
+                    let condition = ty::TyExpression {
+                        expression: ty::TyExpressionVariant::Literal(Literal::Boolean(true)),
+                        return_type: type_engine.insert_type(TypeInfo::Boolean),
+                        span: self.span.clone(),
+                    };
+                    let unit_exp = ty::TyExpression {
+                        expression: ty::TyExpressionVariant::Tuple { fields: vec![] },
+                        return_type: self.return_type_id,
+                        span: self.span.clone(),
+                    };
+                    let then_exp = ty::TyExpression {
+                        expression: ty::TyExpressionVariant::Return(Box::new(unit_exp)),
+                        return_type: self.return_type_id,
+                        span: self.span.clone(),
+                    };
+                    let inner_exp = ty::TyExpressionVariant::IfExp {
+                        condition: Box::new(condition),
+                        then: Box::new(then_exp.clone()),
+                        r#else: Option::Some(Box::new(then_exp)),
+                    };
+                    let typed_if_exp = ty::TyExpression {
+                        expression: inner_exp,
+                        return_type: self.return_type_id,
+                        span: self.span,
+                    };
+                    return ok(typed_if_exp, warnings, errors);
+                }
+
                 errors.push(CompileError::Internal(
                     "unable to convert match exp to if exp",
                     self.span,

--- a/sway-core/src/type_system/type_info.rs
+++ b/sway-core/src/type_system/type_info.rs
@@ -1629,6 +1629,15 @@ impl TypeInfo {
         }
     }
 
+    /// Checks if a given [TypeInfo] has a valid constructor.
+    pub(crate) fn has_valid_constructor(&self) -> bool {
+        match self {
+            TypeInfo::Unknown => false,
+            TypeInfo::Enum { variant_types, .. } => !variant_types.is_empty(),
+            _ => true,
+        }
+    }
+
     /// Given a `TypeInfo` `self`, expect that `self` is a `TypeInfo::Tuple`,
     /// and return its contents.
     ///

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_empty_enums/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_empty_enums/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-C5152A20E944C793'
+
+[[package]]
+name = 'match_expressions_empty_enums'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-C5152A20E944C793'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_empty_enums/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_empty_enums/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "match_expressions_empty_enums"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_empty_enums/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_empty_enums/json_abi_oracle.json
@@ -1,0 +1,22 @@
+{
+  "functions": [
+    {
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "u64",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_empty_enums/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_empty_enums/src/main.sw
@@ -1,0 +1,23 @@
+script;
+
+enum MyNever {}
+
+impl MyNever {
+    fn into_any<T>(self) -> T {
+        match self {}
+    }
+}
+
+fn result_into_ok<T>(res: Result<T, MyNever>) -> T {
+    match res {
+        Result::Ok(t) => t,
+        // This branch can never be taken, and so the
+        // compiler is happy to treat it as evaluating
+        // to whatever type we wish - in this case, `T`.
+        Result::Err(never) => match never {},
+    }
+}
+
+fn main() -> u64 {
+    42
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_empty_enums/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_empty_enums/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 42 }
+validate_abi = true


### PR DESCRIPTION
Closes FuelLabs#1679